### PR TITLE
Fixed cmsis_generic.h header

### DIFF
--- a/cmsis-core/core_generic.h
+++ b/cmsis-core/core_generic.h
@@ -15,6 +15,7 @@
 #else
   #error "Unknown platform for core_generic.h"
 #endif
+#undef __CMSIS_GENERIC
 
 #endif // #ifndef __CMSIS_CORE_CORE_GENERIC_H__
 


### PR DESCRIPTION
Added #undef __CMSIS_GENERIC to prevent huge bunch of extremely weird errors from
other parts of the code that use the "regular" (non generic) CMSIS.
