### PR TITLE
Added cmsis_nvic.{c,h} files from hw-specific modules

### DIFF
--- a/cmsis-core/cmsis_nvic.h
+++ b/cmsis-core/cmsis_nvic.h
@@ -45,7 +45,21 @@
 extern "C" {
 #endif
 
+/** Set the ISR for IRQn
+ *
+ * Sets an Interrupt Service Routine vector for IRQn; if the feature is available, the vector table is relocated to SRAM
+ * the first time this function is called
+ * @param[in] IRQn   The Interrupt Request number for which a vector will be registered
+ * @param[in] vector The ISR vector to register for IRQn
+ */
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+
+/** Get the ISR registered for IRQn
+ *
+ * Reads the Interrupt Service Routine currently registered for IRQn
+ * @param[in] IRQn   The Interrupt Request number the vector of which will be read
+ * @return           Returns the ISR registered for IRQn
+ */
 uint32_t NVIC_GetVector(IRQn_Type IRQn);
 
 #ifdef __cplusplus

--- a/cmsis-core/cmsis_nvic.h
+++ b/cmsis-core/cmsis_nvic.h
@@ -1,0 +1,55 @@
+/* mbed Microcontroller Library
+ * CMSIS-style functionality to support dynamic vectors
+ *******************************************************************************
+ * Copyright (c) 2011 ARM Limited. All rights reserved.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of ARM Limited nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+
+#ifndef MBED_CMSIS_NVIC_H
+#define MBED_CMSIS_NVIC_H
+
+#include "cmsis.h"
+
+#define NVIC_USER_IRQ_OFFSET YOTTA_CFG_CMSIS_NVIC_USER_IRQ_OFFSET
+#define NVIC_USER_IRQ_NUMBER YOTTA_CFG_CMSIS_NVIC_USER_IRQ_NUMBER
+#define NVIC_NUM_VECTORS     (NVIC_USER_IRQ_OFFSET + NVIC_USER_IRQ_NUMBER)
+
+#define NVIC_RAM_VECTOR_ADDRESS   YOTTA_CFG_CMSIS_NVIC_RAM_VECTOR_ADDRESS
+#define NVIC_FLASH_VECTOR_ADDRESS YOTTA_CFG_CMSIS_NVIC_FLASH_VECTOR_ADDRESS
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+uint32_t NVIC_GetVector(IRQn_Type IRQn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/source/cmsis_nvic.c
+++ b/source/cmsis_nvic.c
@@ -30,6 +30,13 @@
  */
 #include "cmsis-core/cmsis_nvic.h"
 
+/* Cortex-M0 cores do not have the VTOR register for vectors relocation, and
+ * some of them might implement an alternative method for that purpose; hence we
+ * require targets based on them to implement their own versions of these
+ * functions */
+/* The same applies for Cortex-M0+ targets as VTOR is not always present */
+#if !defined(TARGET_LIKE_CORTEX_M0) && !defined(TARGET_LIKE_CORTEX_M0PLUS)
+
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
     uint32_t *vectors = (uint32_t *) SCB->VTOR;
@@ -52,3 +59,5 @@ uint32_t NVIC_GetVector(IRQn_Type IRQn)
     uint32_t *vectors = (uint32_t *) SCB->VTOR;
     return vectors[IRQn + NVIC_USER_IRQ_OFFSET];
 }
+
+#endif /* !defined(TARGET_LIKE_CORTEX_M0) && !defined(TARGET_LIKE_CORTEX_M0PLUS) */

--- a/source/cmsis_nvic.c
+++ b/source/cmsis_nvic.c
@@ -1,0 +1,54 @@
+/* mbed Microcontroller Library
+ * CMSIS-style functionality to support dynamic vectors
+ *******************************************************************************
+ * Copyright (c) 2011 ARM Limited. All rights reserved.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of ARM Limited nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "cmsis-core/cmsis_nvic.h"
+
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
+{
+    uint32_t *vectors = (uint32_t *) SCB->VTOR;
+    uint32_t i;
+
+    /* Copy and switch to dynamic vectors if the first time called */
+    if (SCB->VTOR == NVIC_FLASH_VECTOR_ADDRESS) {
+        uint32_t *old_vectors = vectors;
+        vectors = (uint32_t *) NVIC_RAM_VECTOR_ADDRESS;
+        for (i = 0; i < NVIC_NUM_VECTORS; i++) {
+            vectors[i] = old_vectors[i];
+        }
+        SCB->VTOR = (uint32_t) NVIC_RAM_VECTOR_ADDRESS;
+    }
+    vectors[IRQn + NVIC_USER_IRQ_OFFSET] = vector;
+}
+
+uint32_t NVIC_GetVector(IRQn_Type IRQn)
+{
+    uint32_t *vectors = (uint32_t *) SCB->VTOR;
+    return vectors[IRQn + NVIC_USER_IRQ_OFFSET];
+}


### PR DESCRIPTION
This PR adds `cmsis_nvic.*` files to `cmsis-core`, which is hw-independent, to avoid code duplication. The same files are being removed in related PRs from the hw-specific `cmsis-core-*` modules.

The files require yotta config entries for the definition of NVIC offsets/addresses (see related PRs).