### PR TITLE
Only build cmsis_nvic.c if target cpu has the VTOR register

### DIFF
--- a/module.json
+++ b/module.json
@@ -37,6 +37,9 @@
     },
     "nordic": {
       "cmsis-core-nordic": "~0.0.1"
+    },
+    "nxp": {
+      "cmsis-core-nxp": ">=0.1.0"
     }
   }
 }


### PR DESCRIPTION
Cortex-M0 targets like the NXP LPC111x and Nordic nRF51822 don't have the VTOR register while
Cortex-M{0+,3,4,7} devices and all future Cortex-M targets likely will.

Thus add a source/CMakeLists.txt,
set TARGET_HAS_VTOR_FOR_VECTOR_RELOCATION to TRUE only if
"!TARGET_LIKE_CORTEX_M0" in there and guard building of cmsis_nvic.c
on that.

Note that cmsis-core-lpc111x provides its own cmsis_nvic.c
implemented by using the NXP specific SYSMEMREMAP feature.