### PR TITLE
add targetDependency on cmsis-core-nxp

### DIFF
--- a/module.json
+++ b/module.json
@@ -37,6 +37,9 @@
     },
     "nordic": {
       "cmsis-core-nordic": "~0.0.1"
+    },
+    "nxp": {
+      "cmsis-core-nxp": ">=0.1.0"
     }
   }
 }


### PR DESCRIPTION
I've added CMSIS-CORE support for the NXP LPC1114 in cmsis-core-lpc111x
and this patch enables it in cmsis-core.