### PR TITLE
Vectors - for m0 either specify has vtor or custom vtor

### DIFF
--- a/source/cmsis_nvic.c
+++ b/source/cmsis_nvic.c
@@ -62,6 +62,6 @@ uint32_t NVIC_GetVector(IRQn_Type IRQn)
 
 #elif !defined(YOTTA_CFG_CMSIS_NVIC_HAS_CUSTOM_VTOR)
 
-#error The target should define yotta config cmsis-nvic:has-vtor, or cmsis-nvic:has-custom-vtor + implement NVIC_SetVector/NVIC_GetVector
+#error The target should define yotta config cmsis-nvic.has-vtor, or cmsis-nvic.has-custom-vtor + implement NVIC_SetVector/NVIC_GetVector
 
 #endif /* !defined(TARGET_LIKE_CORTEX_M0) && !defined(TARGET_LIKE_CORTEX_M0PLUS) */

--- a/source/cmsis_nvic.c
+++ b/source/cmsis_nvic.c
@@ -35,7 +35,7 @@
  * require targets based on them to implement their own versions of these
  * functions */
 /* The same applies for Cortex-M0+ targets as VTOR is not always present */
-#if !defined(TARGET_LIKE_CORTEX_M0) && !defined(TARGET_LIKE_CORTEX_M0PLUS)
+#if (!defined(TARGET_LIKE_CORTEX_M0) && !defined(TARGET_LIKE_CORTEX_M0PLUS)) || defined(YOTTA_CFG_CMSIS_NVIC_HAS_VTOR)
 
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
 {
@@ -59,5 +59,9 @@ uint32_t NVIC_GetVector(IRQn_Type IRQn)
     uint32_t *vectors = (uint32_t *) SCB->VTOR;
     return vectors[IRQn + NVIC_USER_IRQ_OFFSET];
 }
+
+#elif !defined(YOTTA_CFG_CMSIS_NVIC_HAS_CUSTOM_VTOR)
+
+#error The target should define yotta config cmsis-nvic:has-vtor, or cmsis-nvic:has-custom-vtor + implement NVIC_SetVector/NVIC_GetVector
 
 #endif /* !defined(TARGET_LIKE_CORTEX_M0) && !defined(TARGET_LIKE_CORTEX_M0PLUS) */


### PR DESCRIPTION
- This addresses an issue that there are many M0 which could get this generic Set/GetVector without copying the same implementation - define yotta config cmsis-nvic:has-vtor to enable it for M0/M0+.

or

- Your feedback for this - The another one is that a new target gets currently undefined SetGetVector which is fine but it's not clear why/how to implement one. Adding here an error with a description what is needed and why. This can be silenced by defining yotta config cmsis-nvic:has-custom-vtor

@bogdanm @AlessandroA @autopulated @maclobdell 