### PR TITLE
NVIC - first time set old vectors to flash vector address

### DIFF
--- a/source/cmsis_nvic.c
+++ b/source/cmsis_nvic.c
@@ -43,8 +43,8 @@ void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector)
     uint32_t i;
 
     /* Copy and switch to dynamic vectors if the first time called */
-    if (SCB->VTOR == NVIC_FLASH_VECTOR_ADDRESS) {
-        uint32_t *old_vectors = vectors;
+    if (SCB->VTOR != NVIC_RAM_VECTOR_ADDRESS) {
+        uint32_t *old_vectors = (uint32_t *) NVIC_FLASH_VECTOR_ADDRESS;
         vectors = (uint32_t *) NVIC_RAM_VECTOR_ADDRESS;
         for (i = 0; i < NVIC_NUM_VECTORS; i++) {
             vectors[i] = old_vectors[i];


### PR DESCRIPTION
VTOR is set the NVIC_FLASH_VECTOR_ADDRESS before the vectors are copied to RAM which from a yotta config.

This is a fix for targets with bootloaders.

@bogdanm @AlessandroA 