### PR TITLE
Add ublox cmsis-core to the list.

### DIFF
--- a/module.json
+++ b/module.json
@@ -56,7 +56,7 @@
       "cmsis-core-atmel": "^1.0.0"
     },
     "ublox": {
-      "mbed-hal-ublox": "^0.0.1"
+      "cmsis-core-ublox": "^0.0.1"
     }
   }
 }

--- a/module.json
+++ b/module.json
@@ -54,6 +54,9 @@
     },
     "atmel": {
       "cmsis-core-atmel": "^1.0.0"
+    },
+    "ublox": {
+      "mbed-hal-ublox": "^0.0.1"
     }
   }
 }


### PR DESCRIPTION
This is the first step towards adding u-blox targets to mbedOS, as instructed by @screamerbg.  A similar pull request is submitted for mbed-hal.  Once this is merged further modules/targets will be submitted to match.
